### PR TITLE
Revamp course editing and meeting visuals

### DIFF
--- a/Sean/ColorExtensions.swift
+++ b/Sean/ColorExtensions.swift
@@ -6,6 +6,12 @@
 //
 
 import SwiftUI
+#if canImport(AppKit)
+import AppKit
+#endif
+#if canImport(UIKit)
+import UIKit
+#endif
 
 extension Color {
     init?(hex: String) {
@@ -41,24 +47,54 @@ extension Color {
         self.init(red: r, green: g, blue: b, opacity: a)
     }
     
-        func toHexString() -> String? {
-            #if canImport(AppKit)
-            let nsColor = NSColor(self)
-            guard let rgbColor = nsColor.usingColorSpace(.deviceRGB) else { return nil }
-            let r = Int(rgbColor.redComponent * 255)
-            let g = Int(rgbColor.greenComponent * 255)
-            let b = Int(rgbColor.blueComponent * 255)
-            return String(format: "#%02X%02X%02X", r, g, b)
-            #elseif canImport(UIKit)
-            let uiColor = UIColor(self)
-            var r: CGFloat = 0
-            var g: CGFloat = 0
-            var b: CGFloat = 0
-            var a: CGFloat = 0
-            guard uiColor.getRed(&r, green: &g, blue: &b, alpha: &a) else { return nil }
-            return String(format: "#%02X%02X%02X", Int(r * 255), Int(g * 255), Int(b * 255))
-            #else
-            return nil
-            #endif
-        }
+    func toHexString() -> String? {
+        #if canImport(AppKit)
+        let nsColor = NSColor(self)
+        guard let rgbColor = nsColor.usingColorSpace(.deviceRGB) else { return nil }
+        let r = Int(rgbColor.redComponent * 255)
+        let g = Int(rgbColor.greenComponent * 255)
+        let b = Int(rgbColor.blueComponent * 255)
+        return String(format: "#%02X%02X%02X", r, g, b)
+        #elseif canImport(UIKit)
+        let uiColor = UIColor(self)
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        guard uiColor.getRed(&r, green: &g, blue: &b, alpha: &a) else { return nil }
+        return String(format: "#%02X%02X%02X", Int(r * 255), Int(g * 255), Int(b * 255))
+        #else
+        return nil
+        #endif
+    }
+
+    static var platformCardBackground: Color {
+        #if canImport(UIKit)
+        return Color(UIColor.secondarySystemGroupedBackground)
+        #elseif canImport(AppKit)
+        return Color(nsColor: NSColor.windowBackgroundColor)
+        #else
+        return Color.gray.opacity(0.15)
+        #endif
+    }
+
+    static var platformChipBackground: Color {
+        #if canImport(UIKit)
+        return Color(UIColor.systemGray5)
+        #elseif canImport(AppKit)
+        return Color(nsColor: NSColor.controlBackgroundColor)
+        #else
+        return Color.gray.opacity(0.25)
+        #endif
+    }
+
+    static var platformElevatedBackground: Color {
+        #if canImport(UIKit)
+        return Color(UIColor.tertiarySystemGroupedBackground)
+        #elseif canImport(AppKit)
+        return Color(nsColor: NSColor.underPageBackgroundColor)
+        #else
+        return Color.gray.opacity(0.1)
+        #endif
+    }
 }

--- a/Sean/CourseMeeting.swift
+++ b/Sean/CourseMeeting.swift
@@ -17,15 +17,26 @@ final class CourseMeeting {
     var startMinute: Int
     var endHour: Int
     var endMinute: Int
+    var meetingType: String
     @Relationship var course: Course?
 
-    init(id: UUID = UUID(), dayOfWeek: Int, startHour: Int, startMinute: Int, endHour: Int, endMinute: Int, course: Course? = nil) {
+    init(
+        id: UUID = UUID(),
+        dayOfWeek: Int,
+        startHour: Int,
+        startMinute: Int,
+        endHour: Int,
+        endMinute: Int,
+        meetingType: String = "Class",
+        course: Course? = nil
+    ) {
         self.id = id
         self.dayOfWeek = dayOfWeek
         self.startHour = startHour
         self.startMinute = startMinute
         self.endHour = endHour
         self.endMinute = endMinute
+        self.meetingType = meetingType
         self.course = course
     }
 }

--- a/Sean/Lecture.swift
+++ b/Sean/Lecture.swift
@@ -13,15 +13,24 @@ final class Lecture {
     var id: UUID
     var title: String
     var date: Date
+    var meetingType: String?
     var notes: String?
     @Relationship(deleteRule: .cascade, inverse: \LectureNote.lecture) var lectureNotes: [LectureNote] = []
     @Relationship(deleteRule: .cascade, inverse: \LectureFile.lecture) var lectureFiles: [LectureFile] = []
     @Relationship var course: Course?
 
-    init(id: UUID = UUID(), title: String, date: Date, notes: String? = nil, course: Course? = nil) {
+    init(
+        id: UUID = UUID(),
+        title: String,
+        date: Date,
+        meetingType: String? = nil,
+        notes: String? = nil,
+        course: Course? = nil
+    ) {
         self.id = id
         self.title = title
         self.date = date
+        self.meetingType = meetingType
         self.notes = notes
         self.course = course
     }


### PR DESCRIPTION
## Summary
- add meeting-type selection and validation to new courses while persisting the choice on CourseMeeting and Lecture models
- redesign the course edit workflow with card-based identity, scheduling, and preview sections plus safer meeting regeneration
- refresh lecture and schedule surfaces to highlight course colors and session types while simplifying dashboard quick actions

## Testing
- Not run (requires macOS/Xcode environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4a6411224832eb86643a631ad3be2